### PR TITLE
feat: DAVE protocol support

### DIFF
--- a/src/api/REST.ts
+++ b/src/api/REST.ts
@@ -478,6 +478,11 @@ export interface VoiceState {
      * The Discord voice session id to authenticate with.
      */
     sessionId: string
+
+    /**
+     * The Discord voice channel id the bot is connecting to.
+     */
+    channelId?: string
 }
 
 export interface Filters {


### PR DESCRIPTION
This pull request adds [DAVE](https://daveprotocol.com/) (Discord audio & video encryption) protocol to lavaluna.js. The DAVE protocol was introduced in September 2024, and as of 2 March 2026, no clients are allowed to communicate in voice without it. Consequently, any client that tries to use lavaluna.js for music playback is faced with a voice close code 4017 as documented [here](https://docs.discord.com/developers/topics/opcodes-and-status-codes#voice) and other parties in a voice channel can hear nothing from that client.

The encryption work is being done by Lavalink, so we don't need to bundle any extra libraries. What we do need to do, though, is to provide a voice channel ID (`channelId`) that the client is connected to whenever the voice state update event is fired. You can learn more from Lavalink [docs](https://lavalink.dev/api/rest.html#voice-state). Also per this [comment](https://github.com/shipgirlproject/Shoukaku/pull/231#discussion_r2853861770), `channelId` may be optional.