### PR TITLE
refactor: adopt discord-api-types and tighten tooling config

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+[*]
+charset = utf-8
+indent_size = 4
+indent_style = space
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{json,yml,yaml}]
+indent_size = 2

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,3 @@
+dist
+node_modules
+package-lock.json

--- a/.prettierrc
+++ b/.prettierrc
@@ -5,9 +5,11 @@
     "semi": false,
     "arrowParens": "avoid",
     "printWidth": 120,
+    "endOfLine": "lf",
+    "useTabs": false,
     "overrides": [
         {
-            "files": ["*.json", "*.yml"],
+            "files": ["*.json", "*.yml", "*.yaml"],
             "options": {
                 "tabWidth": 2
             }

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
       "devDependencies": {
         "@types/node": "^25.2.3",
         "@types/ws": "^8.18.1",
+        "discord-api-types": "^0.38.49",
         "tsup": "^8.5.1",
         "typescript": "^5.9.3"
       }
@@ -1095,6 +1096,16 @@
           "optional": true
         }
       }
+    },
+    "node_modules/discord-api-types": {
+      "version": "0.38.49",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.49.tgz",
+      "integrity": "sha512-XnqcWmnFZFAE8ZM8SHAw9DIV8D3Or00rMQ8iQLotrEA2PmXhl+ykaf6L6q4l474hrSUH1JaYcv+iOMRWp2p6Tg==",
+      "dev": true,
+      "license": "MIT",
+      "workspaces": [
+        "scripts/actions/documentation"
+      ]
     },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   "devDependencies": {
     "@types/node": "^25.2.3",
     "@types/ws": "^8.18.1",
+    "discord-api-types": "^0.38.49",
     "tsup": "^8.5.1",
     "typescript": "^5.9.3"
   },

--- a/src/api/REST.ts
+++ b/src/api/REST.ts
@@ -478,6 +478,11 @@ export interface VoiceState {
      * The Discord voice session id to authenticate with.
      */
     sessionId: string
+
+    /**
+     * The Discord voice channel id the bot is connecting to.
+     */
+    channelId: string
 }
 
 export interface Filters {

--- a/src/managers/DataManager.ts
+++ b/src/managers/DataManager.ts
@@ -25,7 +25,7 @@ export class DataManager<K, V> {
     }
 
     /** Finds a value in the cache matching the given predicate. */
-    public find = this.cache.find
+    public find = this.cache.find.bind(this.cache) as typeof this.cache.find
     /** Deletes an entry from the cache by key. */
-    public delete = this.cache.delete
+    public delete = this.cache.delete.bind(this.cache) as typeof this.cache.delete
 }

--- a/src/managers/Lavaluna.ts
+++ b/src/managers/Lavaluna.ts
@@ -1,3 +1,9 @@
+import {
+    GatewayDispatchEvents,
+    GatewayVoiceServerUpdateDispatch,
+    GatewayVoiceStateUpdate,
+    GatewayVoiceStateUpdateDispatch
+} from 'discord-api-types/gateway/v10'
 import EventEmitter from 'events'
 import { APIPlayer, Track } from '../api/REST'
 import { Exception, WebSocketClosedEvent } from '../api/WebSocket'
@@ -60,7 +66,7 @@ export class Lavaluna extends EventEmitter<LavalunaEvents> {
     /**
      * Shortcut for {@link NodeManager.search}.
      */
-    public search = this.nodes.search
+    public search = this.nodes.search.bind(this.nodes) as typeof this.nodes.search
 
     /**
      * Sends voice data to the Lavalink server.
@@ -68,10 +74,13 @@ export class Lavaluna extends EventEmitter<LavalunaEvents> {
      * @param data - The data to update voice state.
      * @returns The updated player.
      */
-    public async updateVoiceState(data: DiscordVoicePacket): Promise<APIPlayer> {
-        if ('t' in data && !['VOICE_STATE_UPDATE', 'VOICE_SERVER_UPDATE'].includes(data.t)) return null
+    public async updateVoiceState(
+        data: GatewayVoiceServerUpdateDispatch | GatewayVoiceStateUpdateDispatch
+    ): Promise<APIPlayer> {
+        if (data.t !== GatewayDispatchEvents.VoiceServerUpdate && data.t !== GatewayDispatchEvents.VoiceStateUpdate)
+            return null
 
-        const update: DiscordVoiceServer | DiscordVoiceState = data.d
+        const update = data.d
         if (!update || (!('token' in update) && !('session_id' in update))) return null
 
         const player = this.nodes.getPlayer(update.guild_id)
@@ -94,6 +103,7 @@ export class Lavaluna extends EventEmitter<LavalunaEvents> {
                 }
 
                 player.voiceState.sessionId = update.session_id
+                player.voiceState.channelId = update.channel_id
                 player.voiceChannelId = update.channel_id
             } else {
                 // Player got disconnected.
@@ -110,7 +120,8 @@ export class Lavaluna extends EventEmitter<LavalunaEvents> {
                 voice: {
                     token: player.voiceState.token,
                     endpoint: player.voiceState.endpoint,
-                    sessionId: player.voiceState.sessionId
+                    sessionId: player.voiceState.sessionId,
+                    channelId: player.voiceState.channelId
                 }
             })
         }
@@ -159,67 +170,5 @@ export interface LavalunaOptions {
     /**
      * Function to send data to the shard.
      */
-    send(id: string, payload: LavalunaOptionsSendPayload): void
-}
-
-export interface LavalunaOptionsSendPayload {
-    /** The OP code */
-    op: number
-    d: {
-        guild_id: string
-        channel_id: string | null
-        self_mute: boolean
-        self_deaf: boolean
-    }
-}
-
-export interface DiscordVoicePacket {
-    /**
-     * The type of packet.
-     */
-    t?: 'VOICE_SERVER_UPDATE' | 'VOICE_STATE_UPDATE'
-
-    /**
-     * The data of the packet.
-     */
-    d: DiscordVoiceState | DiscordVoiceServer
-}
-
-export interface DiscordVoiceServer {
-    /**
-     * The token to use.
-     */
-    token: string
-
-    /**
-     * The guild ID.
-     */
-    guild_id: string
-
-    /**
-     * The endpoint to use.
-     */
-    endpoint: string
-}
-
-export interface DiscordVoiceState {
-    /**
-     * The guild ID.
-     */
-    guild_id: string
-
-    /**
-     * The user ID.
-     */
-    user_id: string
-
-    /**
-     * The session ID.
-     */
-    session_id: string
-
-    /**
-     * The channel ID.
-     */
-    channel_id: string
+    send(id: string, payload: GatewayVoiceStateUpdate): void
 }

--- a/src/structures/Player.ts
+++ b/src/structures/Player.ts
@@ -1,3 +1,4 @@
+import { GatewayOpcodes } from 'discord-api-types/gateway/v10'
 import { APIPlayer, Filters, VoiceState } from '../api/REST'
 import { isValidTrack } from '../utils/Utils'
 import { Node } from './Node'
@@ -80,7 +81,10 @@ export class Player {
 
     private readonly data: Record<string, any> = {}
 
-    constructor(public node: Node, public readonly options: PlayerOptions) {
+    constructor(
+        public node: Node,
+        public readonly options: PlayerOptions
+    ) {
         this.guildId = options.guildId
         this.voiceChannelId = options.voiceChannelId
         this.textChannelId = options.textChannelId
@@ -101,7 +105,7 @@ export class Player {
         this.state = 'CONNECTING'
 
         this.node.manager.options.send(this.guildId, {
-            op: 4,
+            op: GatewayOpcodes.VoiceStateUpdate,
             d: {
                 guild_id: this.guildId,
                 channel_id: this.voiceChannelId,


### PR DESCRIPTION
Replace custom Discord voice packet interfaces with discord-api-types gateway types, add channelId to VoiceState, use GatewayOpcodes enum instead of magic opcode 4, and fix missing .bind() on delegated methods. Also adds .editorconfig and tightens Prettier config.